### PR TITLE
Level End Stuff

### DIFF
--- a/Assets/Scripts/LevelEnd.cs
+++ b/Assets/Scripts/LevelEnd.cs
@@ -1,0 +1,54 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Events;
+
+public class LevelEnd : MonoBehaviour
+{
+    [Tooltip("How long both the player and creature should be here before triggering the events")]
+    [SerializeField] float waitTime = 5;
+    [Tooltip("Events to invoke when the player and creature have been in here for the wait time (pop ups, changing scenes, cutscenes, etc)")]
+    [SerializeField] UnityEvent finishEvent;
+    float waitTimer = 0;
+    bool creature, player;
+
+    private void Update()
+    {
+        if (waitTimer > 0)
+        {
+            waitTimer -= Time.deltaTime;
+            if (waitTimer <= 0 && creature && player)
+            {
+                finishEvent.Invoke();
+            }
+        }
+    }
+
+    private void OnTriggerEnter(Collider other)
+    {
+        if (other.gameObject.GetComponent<CreatureController>() != null) 
+        { 
+            creature = true;
+        }
+        else if (other.gameObject.GetComponent<PlayerController>() != null) 
+        {
+            player = true;
+        }
+        if (player && creature)
+            waitTimer = waitTime;
+    }
+
+    private void OnTriggerExit(Collider other)
+    {
+        if (other.gameObject.GetComponent<CreatureController>() != null)
+        {
+            creature = false;
+            waitTimer = 0;
+        }
+        else if (other.gameObject.GetComponent<PlayerController>() != null)
+        {
+            player = false;
+            waitTimer = 0;
+        }
+    }
+}

--- a/Assets/Scripts/LevelEnd.cs.meta
+++ b/Assets/Scripts/LevelEnd.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 80765af89a3e57649ba1983b56c714dc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
From the TDD:

The level end script should be attached to an empty object with a collider with isTrigger set to true. When both the player and creature are within this collider for a set amount of time based on the waitTime variable, the finishEvent will be invoked. Early on, it might be a good idea to load a new scene using this, but in the future it can be replaced by making an “end of level” pop up that lets the player click a button to move on, or even to play a cutscene before transitioning to the next level.